### PR TITLE
adds option to supply ignored list to avoid returning node_modules etc. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ one of the following areas:
 Given an initial directory (e.g. the [Current Working Directory](http://en.wikipedia.org/wiki/Working_directory)) give me a
 list of all the "child" directories.
 
-## How? (usage)
+## How? (Usage)
 
 ### Install from NPM
 
@@ -39,7 +39,7 @@ list of all the "child" directories.
 npm install listdirs --save
 ```
 
-Then in your code:
+### In your code:
 
 ```js
 var listdirs = require('listdirs');
@@ -54,6 +54,31 @@ listdirs(basedir, function callback(err, list){
 });
 ```
 
+#### (*Optional*) Supply a List of Files/Directories to *Ignore*
+
+If you have a large project and want to ignore the files in your
+.gitignore file (e.g. **node_modules**), there's an *easy* way to do this:
+
+```js
+var listdirs = require('listdirs');
+var ignored  = require('ignored')('./.gitignore'); // https://github.com/nelsonic/ignored
+var basedir  = __dirname; // or which ever base directory you prefer
+listdirs(basedir, function callback(err, list){
+    if(err){
+      console.log(err); // handle errors in your preferred way.
+    }
+    else {
+      console.log(list); // use the array of directories as required.
+    }
+}, ignored); // include ignored list as 3rd Parameter (after callback)
+```
+
+***Note***: This example uses our **ignored** module: https://www.npmjs.com/package/ignored
+as an *optional* helper to list the entries in **.gitignore** file  
+but you can supply your list of ignored files as a simple array
+e.g: `var ignored = ['node_modules', '.git', '.vagrant', 'etc.'];`
+
+<br />
 
 ## Research
 

--- a/listdirs.js
+++ b/listdirs.js
@@ -3,16 +3,18 @@ var isdir = require('isdir');
 /**
  * listdirs returns a List of Directories given an initial base directory
  * by walking the directory tree and finding all child directories.
- * accepts two parameters:
+ * accepts three parameters:
  * @param {string} basedir - file descriptor e.g: /dir/child/etc/
  * @param {function} callback - is called once we have the list of directories
  * (or if an error occurs). Your callback should have two arguments:
  *   @param {string} error - an error message or null if no errors.
  *   @param {array} list - a list of directories in the order we found them.
+ * @param {array} ignored - list of files/directories to ignore while walking
  */
-module.exports = function listdirs(basedir, callback) {
-  var list  = []; // the list of dirs we will return
-  var count = 1;  // count used to keep track of what we still need to walk
+module.exports = function listdirs(basedir, callback, ignoredlist) {
+  var list   = []; // the list of dirs we will return
+  var count  = 1;  // count used to keep track of what we still need to walk
+  var ignore = ignoredlist; // if a list of files/dirs to ignore is supplied
 
   function dircheck(fd) {
     isdir(fd, function(err, dir){
@@ -38,8 +40,19 @@ module.exports = function listdirs(basedir, callback) {
       count = count - 1; // subtract the parent directory from the count
       if(count > 0) {
         files.forEach(function(file) { // itterate over the files in the dir
-          return dircheck(dir + '/' + file);
-        })
+          // if we have an ignore array we should not walk anything in that list!
+          if(ignore && Array.isArray(ignore) && ignore.length > 0) {
+            if(ignore.indexOf(file) > -1){
+              count--;
+              return done();
+            }
+            else {
+              return dircheck(dir + '/' + file); // do we need to repeat?
+            }
+          } else {
+            return dircheck(dir + '/' + file); // see what codeclimate says.
+          }
+        }); // end forEach
       }
       else { // directory was empty so we are done walking it!
         return done();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listdirs",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "List all directories recursively given an inital directory",
   "main": "listdirs.js",
   "directories": {
@@ -31,6 +31,7 @@
   "devDependencies": {
     "chalk": "^1.0.0",
     "codeclimate-test-reporter": "0.0.4",
+    "ignored": "^2.0.2",
     "istanbul": "^0.3.4",
     "jshint": "^2.5.10",
     "mkdirp": "^0.5.0",

--- a/test/ignored.js
+++ b/test/ignored.js
@@ -10,9 +10,10 @@ var basedir = path.resolve(__dirname +'/../')
 
 test(cyan('List: ' +basedir+' supplying IGNORED list (.gitignore file)'), function (t) {
   listdirs(basedir, function(err, list) {
-    // console.log(red(err));
-    // console.log(cyan(' - - - - - - - - - - - - - - - - - - - - - - - - - - - - '))
-    // console.log(list);
+    console.log(red(err));
+    console.log(cyan(' - - - - - - - - - - - - - - - - - - - - - - - - - - - - '))
+    console.log(list);
+    console.log("List: "+red(list.length));
     t.equal(list.length, 9, green("✓ List contains Only 9 dirs ignored list supplied."));
     t.end();
   }, ignored);
@@ -23,7 +24,8 @@ test(cyan('List: ' +basedir+' without supplying ignored list (.gitignore file)')
     // console.log(red(err));
     // console.log(cyan(' - - - - - - - - - - - - - - - - - - - - - - - - - - - - '))
     // console.log(list);
-    t.true(list.length > 500, green("✓ List contains 548 dirs when NO IGNORED LIST Supplied."));
+    console.log("List: "+red(list.length));
+    t.true(list.length > 500, green("✓ List contains " + list.length + "dirs when NO IGNORED LIST Supplied."));
     t.end();
   });
 });

--- a/test/ignored.js
+++ b/test/ignored.js
@@ -10,22 +10,32 @@ var basedir = path.resolve(__dirname +'/../')
 
 test(cyan('List: ' +basedir+' supplying IGNORED list (.gitignore file)'), function (t) {
   listdirs(basedir, function(err, list) {
-    console.log(red(err));
-    console.log(cyan(' - - - - - - - - - - - - - - - - - - - - - - - - - - - - '))
-    console.log(list);
-    console.log("List: "+red(list.length));
-    t.equal(list.length, 9, green("✓ List contains Only 9 dirs ignored list supplied."));
+    console.log(cyan(" - - - - - - - - - - - - - - - - - - - - - - - - - "));
+    console.log(list)
+    console.log(cyan(" - - - - - - - - - - - - - - - - - - - - - - - - - "));
+    var found = false;
+    list.forEach(function(item) { // search through list of items for node_modules
+      if(!found && item.indexOf('node_modules') > 0) {
+        found = true;
+        t.true(found, "✓ " + cyan(item) + " in List contains node_modules")
+      }
+    });
+    t.true(!found, "✓ List does NOT contain node_modules")
+    t.true(list.length < 10, green("✓ List contains " + red(list.length) + " dirs when ignored list supplied."));
     t.end();
   }, ignored);
 });
 
 test(cyan('List: ' +basedir+' without supplying ignored list (.gitignore file)'), function (t) {
   listdirs(basedir, function(err, list) {
-    // console.log(red(err));
-    // console.log(cyan(' - - - - - - - - - - - - - - - - - - - - - - - - - - - - '))
-    // console.log(list);
-    console.log("List: "+red(list.length));
-    t.true(list.length > 500, green("✓ List contains " + list.length + "dirs when NO IGNORED LIST Supplied."));
+    var found = false;
+    list.forEach(function(item) { // search through list of items for node_modules
+      if(!found && item.indexOf('node_modules') > 0) {
+        found = true;
+        t.true(found, "✓ " + cyan(item) + " in List contains node_modules")
+      }
+    });
+    t.true(list.length > 400, green("✓ List contains " + red(list.length) + " dirs when NO IGNORED LIST Supplied."));
     t.end();
   });
 });

--- a/test/ignored.js
+++ b/test/ignored.js
@@ -1,0 +1,29 @@
+var test    = require('tape');
+var chalk   = require('chalk');
+var red     = chalk.red, green = chalk.green, cyan = chalk.cyan;
+var path    = require('path');
+var ignored = require('ignored')('./.gitignore'); // get the list of entries in .gitignore
+var listdirs = require('../');
+ignored.push('.git'); // ignore the .git dir
+// console.log(ignored);
+var basedir = path.resolve(__dirname +'/../')
+
+test(cyan('List: ' +basedir+' supplying IGNORED list (.gitignore file)'), function (t) {
+  listdirs(basedir, function(err, list) {
+    // console.log(red(err));
+    // console.log(cyan(' - - - - - - - - - - - - - - - - - - - - - - - - - - - - '))
+    // console.log(list);
+    t.equal(list.length, 9, green("✓ List contains Only 9 dirs ignored list supplied."));
+    t.end();
+  }, ignored);
+});
+
+test(cyan('List: ' +basedir+' without supplying ignored list (.gitignore file)'), function (t) {
+  listdirs(basedir, function(err, list) {
+    // console.log(red(err));
+    // console.log(cyan(' - - - - - - - - - - - - - - - - - - - - - - - - - - - - '))
+    // console.log(list);
+    t.true(list.length > 500, green("✓ List contains 548 dirs when NO IGNORED LIST Supplied."));
+    t.end();
+  });
+});


### PR DESCRIPTION
see: https://github.com/ideaq/listdirs/issues/8
We can ignore the list from .gitignore while walking to avoid returning the massive list containing node_modules and other useless files we don't want to watch in [**Faster**](https://github.com/ideaq/faster)
@iteles let me know if you have any questions. thanks!
